### PR TITLE
Bugfix/make synchronous http requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "command-line-args": "^2.1.3",
     "cron-to-quartz": "^1.1.0",
     "jsonfile": "^2.2.3",
+    "sleep": "^3.0.1",
     "operations-orchestration-api": "^1.0.0"
   }
 }


### PR DESCRIPTION
fixes #5 
refactoring promises to break apart the quartz to crontab conversion and utilize a recursive loop for blocking the OO flow requests being sent

Also add dependency for npm `sleep` module to block http requests.

Problem background:
OO uses the timestamp of the request that came in as a unique id, which causes issues when NodeJS is queuing all the http requests in an async manner, causing some requests to randomly happen to land the server on the exact same second.
